### PR TITLE
* fix InstanceGenerator#inheritAnnotations so that all annotations are inherited

### DIFF
--- a/core/main/src/com/clarkparsia/empire/codegen/InstanceGenerator.java
+++ b/core/main/src/com/clarkparsia/empire/codegen/InstanceGenerator.java
@@ -309,7 +309,9 @@ public final class InstanceGenerator {
 			if (annotationsAttribute != null) {
 				ConstPool cp = theClass.getClassFile().getConstPool();
 				AnnotationsAttribute attr = new AnnotationsAttribute(cp, AnnotationsAttribute.visibleTag);
+				Annotation[] annos = new Annotation[annotationsAttribute.getAnnotations().length];
 
+				int i = 0;
 				for (Object obj : annotationsAttribute.getAnnotations()) {
 
 					Annotation a = (Annotation) obj;
@@ -322,8 +324,10 @@ public final class InstanceGenerator {
 						}
 					}
 
-					attr.setAnnotation(theAnnotation);
+					annos[i] = theAnnotation;
+					i++;
 				}
+				attr.setAnnotations(annos);
 				theMethod.getMethodInfo().addAttribute(attr);
 			}
 		}

--- a/core/main/src/com/clarkparsia/empire/codegen/InstanceGenerator.java
+++ b/core/main/src/com/clarkparsia/empire/codegen/InstanceGenerator.java
@@ -309,9 +309,7 @@ public final class InstanceGenerator {
 			if (annotationsAttribute != null) {
 				ConstPool cp = theClass.getClassFile().getConstPool();
 				AnnotationsAttribute attr = new AnnotationsAttribute(cp, AnnotationsAttribute.visibleTag);
-				Annotation[] annos = new Annotation[annotationsAttribute.getAnnotations().length];
 
-				int i = 0;
 				for (Object obj : annotationsAttribute.getAnnotations()) {
 
 					Annotation a = (Annotation) obj;
@@ -324,10 +322,8 @@ public final class InstanceGenerator {
 						}
 					}
 
-					annos[i] = theAnnotation;
-					i++;
+					attr.addAnnotation(theAnnotation);
 				}
-				attr.setAnnotations(annos);
 				theMethod.getMethodInfo().addAttribute(attr);
 			}
 		}


### PR DESCRIPTION
I had symptom where only one annotation was ever being inherited from my interface methods no matter how many there were. The issue is that <code>attr.setAnnotation(theAnnotation)</code> is being used inside the iteration; it should be <code>setAnnotations(theAnnotations)</code> outside the iteration.